### PR TITLE
bug:inference.py

### DIFF
--- a/inference.py
+++ b/inference.py
@@ -3,6 +3,7 @@ import os
 import cv2
 import numpy as np
 import pandas as pd
+from collections import OrderedDict
 from tqdm.auto import tqdm
 
 import torch
@@ -79,6 +80,8 @@ def test(model, data_loader, thr=0.5):
         for step, (images, image_names) in tqdm(enumerate(data_loader), total=len(data_loader)):
             images = images.cuda()    
             outputs = model(images)
+            if type(outputs) == type(OrderedDict()):
+                outputs = outputs['out']
             
             # restore original size
             outputs = F.interpolate(outputs, size=(2048, 2048), mode="bilinear")


### PR DESCRIPTION
문제점 - 현재 inference.py에서는 torchvision models로 생성된 모델을 이용할 수 없음

원인 - torchvision models는 OrderedDict를 반환하며 key 'out'으로 model의 output을 얻을 수 있음

해결 방안 - inference.py에서 반환 값이 OrderedDict인 경우는 key 'out'으로 output을 찾음